### PR TITLE
MIDI-141: VQVAE Transformer

### DIFF
--- a/configs/config-transformer.yaml
+++ b/configs/config-transformer.yaml
@@ -21,15 +21,16 @@ train:
   loss_lambdas:
     pitch: 1.
     velocity: 1.
-    dstart: 10.
+    dstart: 50.
     duration: 1.
 
 model:
   dim: 256
-  depth: 4
+  depth: 8
   num_heads: 8
   mlp_ratio: 2
   fsq_levels: [8, 8, 8, 6, 5]
+  change_resolution_at_depth: []
 
 paths:
   save_ckpt_dir: "checkpoints" # directory where checkpoints will be saved

--- a/configs/config-transformer.yaml
+++ b/configs/config-transformer.yaml
@@ -1,0 +1,42 @@
+hydra:
+  job:
+    chdir: False
+
+train:
+  dataset_names: [
+    "JasiekKaczmarczyk/giant-midi-sustain-masked",
+    "JasiekKaczmarczyk/pianofor-ai-sustain-masked",
+    "JasiekKaczmarczyk/maestro-v1-sustain-masked",
+  ]
+  batch_size: 128
+  num_workers: 8
+  lr: 3e-4
+  weight_decay: 0.01
+  pitch_shift_probability: 0.5
+  time_stretch_probability: 0.5
+  num_epochs: 10
+  device: "cuda"
+  overfit_single_batch: False
+  # discriminator_warmup: 500
+  loss_lambdas:
+    pitch: 1.
+    velocity: 1.
+    dstart: 10.
+    duration: 1.
+
+model:
+  dim: 256
+  depth: 4
+  num_heads: 8
+  mlp_ratio: 2
+  fsq_levels: [8, 8, 8, 6, 5]
+
+paths:
+  save_ckpt_dir: "checkpoints" # directory where checkpoints will be saved
+  load_ckpt_path: null # if not None, specifies path to model state dict which will be loaded
+  log_dir: "logs"
+  hf_repo_id: null # repo id to upload model to huggingface if null model is not uploaded
+
+logger:
+  run_name: midi-vqvae-transformer-${now:%Y-%m-%d-%H-%M}
+  log_every_n_steps: 100

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -64,13 +64,72 @@ class MidiDataset(Dataset):
             "duration": torch.tensor(record["duration"], dtype=torch.float).clip(0.0, 5.0),
         }
 
-        # data = MidiFeatures(
-        #     filename=record["midi_filename"],
-        #     source=record["source"],
-        #     pitch=torch.tensor(record["pitch"], dtype=torch.long) - 21,
-        #     velocity=(torch.tensor(record["velocity"], dtype=torch.float) / 64) - 1,
-        #     dstart=torch.tensor(record["dstart"], dtype=torch.float),
-        #     duration=torch.tensor(record["duration"], dtype=torch.float).clip(0.0, 5.0),
-        # )
+        return data
+
+
+class MidiDatasetWithStartEnd(Dataset):
+    def __init__(
+        self,
+        dataset: HFDataset,
+        pitch_shift_probability: float = 0.0,
+        time_stretch_probability: float = 0.0,
+    ):
+        super().__init__()
+
+        self.dataset = dataset.with_format("numpy")
+
+        self.pitch_shift_probability = pitch_shift_probability
+        self.time_stretch_probability = time_stretch_probability
+
+    def __rich_repr__(self):
+        yield "MidiDataset"
+        yield "size", len(self)
+        yield "pitch_shift_prob", self.pitch_shift_probability
+        yield "time_stretch_prob", self.time_stretch_probability
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def apply_augmentation(self, record: dict):
+        # shift pitch augmentation
+        if random.random() < self.pitch_shift_probability:
+            shift = 7
+            record["pitch"] = pitch_shift(pitch=record["pitch"], shift_threshold=shift)
+
+        # change tempo augmentation
+        if random.random() < self.time_stretch_probability:
+            record["dstart"], record["duration"] = change_speed(dstart=record["dstart"], duration=record["duration"])
+
+        return record
+
+    def __getitem__(self, index: int) -> dict:
+        record = self.dataset[index]
+
+        # sanity check, replace NaN with 0
+        if np.any(np.isnan(record["dstart"])):
+            record["dstart"] = np.nan_to_num(record["dstart"], copy=False)
+
+        record = self.apply_augmentation(record)
+
+        # clip outliers
+        record["dstart"] = np.clip(record["dstart"], 0.0, 5.0)
+        record["duration"] = np.clip(record["duration"], 0.0, 5.0)
+
+        record["start"] = np.cumsum(record["dstart"])[:-1]
+        record["start"] = np.insert(record["start"], obj=0, values=0.0)
+
+        record["end"] = record["start"] + record["duration"]
+        # record["sequence_duration"] = record["start"][-1] + record["duration"][-1]
+
+        data = {
+            "filename": record["midi_filename"],
+            "source": record["source"],
+            "pitch": torch.tensor(record["pitch"], dtype=torch.long) - 21,
+            "velocity": torch.tensor(record["velocity"], dtype=torch.long),
+            "dstart": torch.tensor(record["dstart"], dtype=torch.float),
+            "duration": torch.tensor(record["duration"], dtype=torch.float),
+            "start": torch.tensor(record["start"], dtype=torch.float),
+            "end": torch.tensor(record["end"], dtype=torch.float),
+        }
 
         return data

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,3 @@
-from models import vqvae, decoder, encoder
+from models import vqvae, decoder, encoder, modules
 
-__all__ = ["vqvae", "encoder", "decoder"]
+__all__ = ["vqvae", "encoder", "decoder", "modules"]

--- a/models/modules/__init__.py
+++ b/models/modules/__init__.py
@@ -2,6 +2,6 @@
 # from .conv_layers import Upsample, Downsample, Residual, PreNorm, ResnetBlock
 # from .attention_layers import ConvAttention, LinearAttention
 
-from . import conv_layers, quantization, attention_layers, features2embedding
+from . import conv_layers, quantization, attention_layers, features2embedding, cape
 
-__all__ = ["conv_layers", "attention_layers", "quantization", "features2embedding"]
+__all__ = ["conv_layers", "attention_layers", "quantization", "features2embedding", "cape"]

--- a/models/modules/attention_layers.py
+++ b/models/modules/attention_layers.py
@@ -1,6 +1,7 @@
 import torch
 import einops
 import torch.nn as nn
+import torch.nn.functional as F
 
 
 class ConvAttention(nn.Module):
@@ -54,5 +55,125 @@ class ConvAttention(nn.Module):
 
         # concatenation of heads
         out = einops.rearrange(out, "n l h d -> n (h d) l")
+
+        return self.out(out)
+
+
+class DownsampleAttention(nn.Module):
+    def __init__(self, dim: int, downsample_factor: int = 2, heads: int = 4, causal: bool = False):
+        super().__init__()
+
+        self.heads = heads
+        self.downsample_factor = downsample_factor
+        self.head_dim = dim // heads
+        self.embedding_size = dim
+        self.causal = causal
+
+        assert self.head_dim * heads == dim, "Channels needs to be dividable by heads"
+
+        self.values_proj = nn.Linear(dim * downsample_factor, dim)
+        self.keys_proj = nn.Linear(dim * downsample_factor, dim)
+        self.queries_proj = nn.Linear(dim * downsample_factor, dim)
+
+        self.out = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = einops.rearrange(x, "n (l p) d -> n l (d p)", p=self.downsample_factor)
+
+        # applying linear projections
+        q = self.queries_proj(x)
+        k = self.keys_proj(x)
+        v = self.values_proj(x)
+
+        # rearranging q, k, v from [batch_size, channels, seq_len] -> [batch_size, seq_len, heads, head_dim]
+        q = einops.rearrange(q, "n l (h d) -> n l h d", h=self.heads)
+        k = einops.rearrange(k, "n l (h d) -> n l h d", h=self.heads)
+        v = einops.rearrange(v, "n l (h d) -> n l h d", h=self.heads)
+
+        # shapes
+        # query: (N, query_len, heads, head_dim)
+        # keys: (N, key_len, heads, head_dim)
+        # output: (N, heads, query_len, key_len)
+        qk = torch.einsum("n q h d, n k h d -> n h q k", [q, k])
+
+        if self.causal:
+            L = qk.shape[-1]
+            mask = torch.tril(torch.ones((L, L), device=qk.device))
+            # setting masked values to -inf so that softmax will give then probability zero
+            qk = qk.masked_fill(mask == 0, float("-inf"))
+
+        # applying softmax over key dimension to calculate attention scores
+        attn = torch.softmax(qk * (self.embedding_size**-0.5), dim=-1)
+
+        # shapes
+        # attn: (N, heads, query_len, key_len)
+        # values: (N, values_len, heads, head_dim)
+        # output: (N, query_len, heads, head_dim)
+        out = torch.einsum("n h q l, n l h d -> n q h d", [attn, v])
+
+        # concatenation of heads
+        out = einops.rearrange(out, "n l h d -> n l (h d)")
+
+        return self.out(out)
+    
+
+class UpsampleAttention(nn.Module):
+    def __init__(self, dim: int, upsample_factor: int = 2, heads: int = 4, causal: bool = False):
+        super().__init__()
+
+        self.heads = heads
+        self.upsample_factor = upsample_factor
+        self.head_dim = dim // heads
+        self.embedding_size = dim
+        self.causal = causal
+
+        assert self.head_dim * heads == dim, "Channels needs to be dividable by heads"
+
+        self.values_proj = nn.Linear(dim, dim)
+        self.keys_proj = nn.Linear(dim, dim)
+        self.queries_proj = nn.Linear(dim, dim)
+
+        self.out = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # upsample q using bilinear interpolation
+        q = einops.rearrange(x, "b l d -> b d l")
+        q = F.interpolate(q, scale_factor=self.upsample_factor, mode="linear")
+        q = einops.rearrange(q, "b d l -> b l d")
+
+        # applying linear projections
+        q = self.queries_proj(q)
+        k = self.keys_proj(x)
+        v = self.values_proj(x)
+
+        # rearranging q, k, v from [batch_size, channels, seq_len] -> [batch_size, seq_len, heads, head_dim]
+        q = einops.rearrange(q, "n l (h d) -> n l h d", h=self.heads)
+        k = einops.rearrange(k, "n l (h d) -> n l h d", h=self.heads)
+        v = einops.rearrange(v, "n l (h d) -> n l h d", h=self.heads)
+
+        # shapes
+        # query: (N, query_len, heads, head_dim)
+        # keys: (N, key_len, heads, head_dim)
+        # output: (N, heads, query_len, key_len)
+        qk = torch.einsum("n q h d, n k h d -> n h q k", [q, k])
+
+        if self.causal:
+            Q = qk.shape[-2]
+            K = qk.shape[-1]
+            mask = torch.tril(torch.ones((Q, K), device=qk.device))
+            # setting masked values to -inf so that softmax will give then probability zero
+            qk = qk.masked_fill(mask == 0, float("-inf"))
+
+        # applying softmax over key dimension to calculate attention scores
+        attn = torch.softmax(qk * (self.embedding_size**-0.5), dim=-1)
+
+        # shapes
+        # attn: (N, heads, query_len, key_len)
+        # values: (N, values_len, heads, head_dim)
+        # output: (N, query_len, heads, head_dim)
+        out = torch.einsum("n h q l, n l h d -> n q h d", [attn, v])
+
+        # concatenation of heads
+        out = einops.rearrange(out, "n l h d -> n l (h d)")
 
         return self.out(out)

--- a/models/modules/cape.py
+++ b/models/modules/cape.py
@@ -1,0 +1,206 @@
+import math
+from typing import Optional, Union
+from einops import rearrange, repeat
+import torch
+from torch import nn
+from torch import Tensor
+
+class CAPE1d(nn.Module):
+    def __init__(self, d_model: int, max_global_shift: float = 0.0, max_local_shift: float = 0.0,
+                 max_global_scaling: float = 1.0, normalize: bool = False, freq_scale: float = 1.0,
+                 batch_first: bool = False):
+        super().__init__()
+
+        assert max_global_shift >= 0, f"""Max global shift is {max_global_shift},
+        but should be >= 0."""
+        assert max_local_shift >= 0, f"""Max local shift is {max_local_shift},
+        but should be >= 0."""
+        assert max_global_scaling >= 1, f"""Global scaling is {max_global_scaling},
+        but should be >= 1."""
+
+        self.max_global_shift = max_global_shift
+        self.max_local_shift = max_local_shift
+        self.max_global_scaling = max_global_scaling
+        self.normalize = normalize
+        self.freq_scale = freq_scale
+        self.batch_first = batch_first
+
+        freq = freq_scale * torch.exp(-2.0 * torch.floor(torch.arange(d_model) / 2)
+                                      * (math.log(1e4) / d_model))
+        self.register_buffer('freq', freq)
+
+        _sin2cos_phase_shift = torch.pi / 2.0
+        cos_shifts = _sin2cos_phase_shift * (torch.arange(d_model) % 2)
+        self.register_buffer('cos_shifts', cos_shifts)
+
+        self.register_buffer('content_scale', Tensor([math.sqrt(d_model)]))
+
+    def forward(self, x: Tensor, x_lengths: Optional[Tensor] = None,
+                positions_delta: Optional[Union[int, Tensor]] = None) -> Tensor:
+        return (x * self.content_scale) + self.compute_pos_emb(x, x_lengths, positions_delta)
+
+    def compute_pos_emb(self, x: Tensor, x_lengths: Optional[Tensor] = None,
+                        positions_delta: Optional[Union[int, Tensor]] = None) -> Tensor:
+        if self.batch_first:
+            batch_size, n_tokens, _ = x.shape # b, t, c
+        else:
+            n_tokens, batch_size, _ = x.shape # t, b, c
+
+        positions = repeat(torch.arange(n_tokens),
+                           't -> new_axis t', new_axis=batch_size).to(x)
+
+        if positions_delta is None:
+            positions_delta = 1
+        else:
+            if torch.is_tensor(positions_delta) and len(positions_delta.shape) == 1:
+                positions_delta = rearrange(positions_delta, 'b -> b 1')
+            positions *= positions_delta
+
+        if x_lengths is not None:
+            padding_mask = positions > x_lengths[:, None]
+            positions[padding_mask] = float('nan')
+
+        if self.normalize:
+            positions -= torch.nanmean(positions, axis=1, keepdim=True)
+
+        positions = self.augment_positions(positions, positions_delta)
+
+        positions = rearrange(positions, 'b t -> b t 1')
+        product = positions * self.freq.to(x)
+
+        pos_emb = torch.sin(product + self.cos_shifts.to(x))
+
+        if not self.batch_first:
+            pos_emb = rearrange(pos_emb, 'b t c -> t b c')
+
+        pos_emb = torch.nan_to_num(pos_emb, nan=0)
+
+        return pos_emb
+
+    def augment_positions(self, positions: Tensor,
+                          positions_delta: Optional[Union[int, Tensor]] = None):
+        if self.training:
+            batch_size, n_tokens = positions.shape
+
+            if self.max_global_shift:
+                delta = torch.FloatTensor(batch_size, 1).uniform_(-self.max_global_shift,
+                                                                  self.max_global_shift)
+                delta = delta.to(positions.device)
+            else:
+                delta = 0
+
+            if self.max_local_shift:
+                epsilon = self.max_local_shift
+                delta_local = torch.FloatTensor(batch_size, n_tokens)
+                delta_local = delta_local.uniform_(-epsilon,
+                                                   epsilon)
+                delta_local = delta_local.to(positions.device)
+                if positions_delta is not None:
+                    if torch.is_tensor(positions_delta) and len(positions_delta.shape) == 1:
+                        positions_delta = rearrange(positions_delta, 'b -> b 1')
+                    delta_local *= positions_delta
+            else:
+                delta_local = 0
+
+            if self.max_global_scaling > 1.0:
+                log_lambdas = torch.FloatTensor(batch_size, 1)
+                log_lambdas = log_lambdas.uniform_(-math.log(self.max_global_scaling),
+                                                   math.log(self.max_global_scaling))
+                log_lambdas = log_lambdas.to(positions.device)
+            else:
+                log_lambdas = torch.zeros(1).to(positions.device)
+
+            positions = (positions + delta + delta_local) * torch.exp(log_lambdas)
+
+        return positions
+
+    def set_content_scale(self, content_scale: float):
+        self.content_scale = Tensor([content_scale])
+
+class CAPE2d(nn.Module):
+    def __init__(self, d_model: int, max_global_shift: float = 0.0, max_local_shift: float = 0.0,
+                 max_global_scaling: float = 1.0, batch_first: bool = False):
+        super().__init__()
+
+        assert max_global_shift >= 0, f"""Max global shift is {max_global_shift},
+        but should be >= 0."""
+        assert max_local_shift >= 0, f"""Max local shift is {max_local_shift},
+        but should be >= 0."""
+        assert max_global_scaling >= 1, f"""Global scaling is {max_global_scaling},
+        but should be >= 1."""
+        assert d_model % 2 == 0, f"""The number of channels should be even,
+                                     but it is odd! # channels = {d_model}."""
+
+        self.max_global_shift = max_global_shift
+        self.max_local_shift = max_local_shift
+        self.max_global_scaling = max_global_scaling
+        self.batch_first = batch_first
+
+        half_channels = d_model // 2
+        rho = 10 ** torch.linspace(0, 1, half_channels)
+        w_x = rho * torch.cos(torch.arange(half_channels))
+        w_y = rho * torch.sin(torch.arange(half_channels))
+        self.register_buffer('w_x', w_x)
+        self.register_buffer('w_y', w_y)
+
+        self.register_buffer('content_scale', Tensor([math.sqrt(d_model)]))
+
+    def forward(self, patches: Tensor) -> Tensor:
+        return (patches * self.content_scale) + self.compute_pos_emb(patches)
+
+    def compute_pos_emb(self, patches: Tensor) -> Tensor:
+        if self.batch_first:
+            batch_size, patches_x, patches_y, _ = patches.shape # b, x, y, c
+        else:
+            patches_x, patches_y, batch_size, _ = patches.shape # x, y, b, c
+
+        x = torch.zeros([batch_size, patches_x, patches_y])
+        y = torch.zeros([batch_size, patches_x, patches_y])
+        x += torch.linspace(-1, 1, patches_x)[None, :, None]
+        y += torch.linspace(-1, 1, patches_y)[None, None, :]
+
+        x, y = self.augment_positions(x, y)
+
+        phase = torch.pi * (self.w_x * x[:, :, :, None]
+                            + self.w_y * y[:, :, :, None])
+        pos_emb = torch.cat([torch.cos(phase), torch.sin(phase)], axis=-1)
+
+        if not self.batch_first:
+            pos_emb = rearrange(pos_emb, 'b x y c -> x y b c')
+
+        return pos_emb
+
+    def augment_positions(self, x: Tensor, y: Tensor):
+        if self.training:
+            batch_size, _, _ = x.shape
+
+            if self.max_global_shift:
+                x += (torch.FloatTensor(batch_size, 1, 1).uniform_(-self.max_global_shift,
+                                                                   self.max_global_shift)
+                     ).to(x.device)
+                y += (torch.FloatTensor(batch_size, 1, 1).uniform_(-self.max_global_shift,
+                                                                   self.max_global_shift)
+                     ).to(y.device)
+
+            if self.max_local_shift:
+                diff_x = x[0, -1, 0] - x[0, -2, 0]
+                diff_y = y[0, 0, -1] - y[0, 0, -2]
+                epsilon_x = diff_x*self.max_local_shift
+                epsilon_y = diff_y*self.max_local_shift
+                x += torch.FloatTensor(x.shape).uniform_(-epsilon_x,
+                                                         epsilon_x).to(x.device)
+                y += torch.FloatTensor(y.shape).uniform_(-epsilon_y,
+                                                         epsilon_y).to(y.device)
+
+            if self.max_global_scaling > 1.0:
+                log_l = math.log(self.max_global_scaling)
+                lambdas = (torch.exp(torch.FloatTensor(batch_size, 1, 1).uniform_(-log_l,
+                                                                                  log_l))
+                          ).to(x.device)
+                x *= lambdas
+                y *= lambdas
+
+        return x, y
+
+    def set_content_scale(self, content_scale: float):
+        self.content_scale = Tensor([content_scale])

--- a/models/modules/positional_embedding.py
+++ b/models/modules/positional_embedding.py
@@ -21,3 +21,23 @@ class SinusoidalPositionEmbeddings(nn.Module):
         self.cache = pe
 
         return pe
+    
+
+class SinusoidalPositionEmbeddingsV2(nn.Module):
+    def __init__(self, embedding_size: int):
+        super().__init__()
+
+        self.embedding_size = embedding_size
+
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, embedding_size, 2).float() / embedding_size))
+        self.register_buffer("inv_freq", inv_freq)
+
+    def forward(self, positions: torch.Tensor):
+        # positions = torch.arange(0, x.shape[1], device=x.device)
+
+        pos_emb = torch.einsum("b i, j-> b i j", positions, self.inv_freq)
+        pe = torch.zeros((positions.shape[0], positions.shape[1], self.embedding_size), device=positions.device)
+        pe[:, :, 0::2] = torch.sin(pos_emb)
+        pe[:, :, 1::2] = torch.cos(pos_emb)
+
+        return pe

--- a/models/vqvae_transformer.py
+++ b/models/vqvae_transformer.py
@@ -1,0 +1,183 @@
+import torch
+import torch.nn as nn
+
+from timm.models.vision_transformer import Block
+from models.modules.cape import CAPE1d
+from models.modules.quantization import FSQ
+from models.modules.features2embedding import TransformerFeatureProjection
+from models.modules.positional_embedding import SinusoidalPositionEmbeddingsV2
+from models.modules.attention_layers import DownsampleAttention, UpsampleAttention
+
+class MidiVQVAETransformer(nn.Module):
+    def __init__(
+        self,
+        dim: int = 768,
+        depth: int = 6,
+        num_heads: int = 12,
+        fsq_levels: list[int] = [8, 8, 8, 6, 5],
+        mlp_ratio: float = 4.0,
+    ):
+        super().__init__()
+
+
+        # list of dimensions
+        quantization_dim = len(fsq_levels)
+        
+        # embedding heads
+        quarter_dim = dim // 4
+        self.pitch_embedding = nn.Embedding(num_embeddings=88, embedding_dim=quarter_dim)
+        self.velocity_embedding = nn.Embedding(num_embeddings=128, embedding_dim=quarter_dim)
+        self.time_embedding = SinusoidalPositionEmbeddingsV2(quarter_dim)
+
+        # self.cape = CAPE1d(quarter_dim, max_global_shift=0.1, max_local_shift=0.5, max_global_scaling=1.4, batch_first=True)
+
+        # encoder
+        self.encoder = nn.ModuleList(
+            [
+                nn.ModuleList([
+                    Block(
+                        dim=dim,
+                        num_heads=num_heads,
+                        mlp_ratio=mlp_ratio,
+                        qkv_bias=True,
+                    ),
+                    Block(
+                        dim=dim,
+                        num_heads=num_heads,
+                        mlp_ratio=mlp_ratio,
+                        qkv_bias=True,
+                    ),
+                    nn.LayerNorm(dim),
+                    DownsampleAttention(dim, downsample_factor=2, heads=num_heads),
+                ])
+                for _ in range(depth)
+            ]
+        )
+        self.out_norm = nn.LayerNorm(dim)
+
+        # fsq
+        self.q_proj_in = nn.Linear(dim, quantization_dim)
+        self.quantizer = FSQ(levels=fsq_levels)
+        self.q_proj_out = nn.Linear(quantization_dim, dim)
+
+        # decoder
+        self.decoder = nn.ModuleList(
+            [
+                nn.ModuleList([
+                    Block(
+                        dim=dim,
+                        num_heads=num_heads,
+                        mlp_ratio=mlp_ratio,
+                        qkv_bias=True,
+                    ),
+                    Block(
+                        dim=dim,
+                        num_heads=num_heads,
+                        mlp_ratio=mlp_ratio,
+                        qkv_bias=True,
+                    ),
+                    nn.LayerNorm(dim),
+                    UpsampleAttention(dim, upsample_factor=2, heads=num_heads),
+                ])
+                for _ in range(depth)
+            ]
+        )
+
+        self.out_norm = nn.LayerNorm(dim)
+
+        self.pitch_out = TransformerFeatureProjection(dim, 88)
+        self.velocity_out = TransformerFeatureProjection(dim, 128)
+        self.dstart_out = TransformerFeatureProjection(dim, 1)
+        self.duration_out = TransformerFeatureProjection(dim, 1)
+
+    def _features_to_embedding(self, pitch: torch.Tensor, velocity: torch.Tensor, start: torch.Tensor, end: torch.Tensor):
+        pitch_emb = self.pitch_embedding(pitch)
+        velocity_emb = self.velocity_embedding(velocity)
+        start_emb = self.time_embedding(start)
+        end_emb = self.time_embedding(end)
+
+        # start_emb = self.cape(start_emb)
+        # end_emb = self.cape(end_emb)
+
+        # shape: [batch_size, seq_len, embedding_dim]
+        x = torch.cat([pitch_emb, velocity_emb, start_emb, end_emb], dim=-1)
+
+        return x
+
+    def _embedding_to_features(self, embedding: torch.Tensor):
+        pitch = self.pitch_out(embedding)
+        velocity = self.velocity_out(embedding)
+        dstart = self.dstart_out(embedding).squeeze(-1)
+        duration = self.duration_out(embedding).squeeze(-1)
+
+        return pitch, velocity, dstart, duration
+
+    def quantize(self, pitch: torch.Tensor, velocity: torch.Tensor, start: torch.Tensor, end: torch.Tensor):
+        x = self._features_to_embedding(pitch, velocity, start, end)
+        for block1, block2, norm, down in self.encoder:
+            x = block1(x)
+            x = block2(x)
+            x = norm(x)
+            x = down(x)
+
+        x = self.out_norm(x)
+        x = self.q_proj_in(x)
+        _, indices = self.quantizer(x)
+
+        return indices
+
+    def dequantize(self, indices: torch.Tensor):
+        codes = self.quantizer.indices_to_codes(indices)
+        x = self.q_proj_out(codes)
+
+        for block1, block2, norm, up in self.decoder:
+            x = block1(x)
+            x = block2(x)
+            x = norm(x)
+            x = up(x)
+
+        x = self.out_norm(x)
+
+        pitch_hat, velocity_hat, dstart_hat, duration_hat = self._embedding_to_features(x)
+
+        return pitch_hat, velocity_hat, dstart_hat, duration_hat
+
+    def forward(self, pitch: torch.Tensor, velocity: torch.Tensor, start: torch.Tensor, end: torch.Tensor):
+        x = self._features_to_embedding(pitch, velocity, start, end)
+
+        for block1, block2, norm, down in self.encoder:
+            x = block1(x)
+            x = block2(x)
+            # x = norm(x)
+            # x = down(x)
+
+        x = self.out_norm(x)
+
+        x = self.q_proj_in(x)
+        codes, _ = self.quantizer(x)
+        x = self.q_proj_out(codes)
+
+        for block1, block2, norm, up in self.decoder:
+            x = block1(x)
+            x = block2(x)
+            # x = norm(x)
+            # x = up(x)
+        
+        x = self.out_norm(x)
+
+        pitch_hat, velocity_hat, dstart_hat, duration_hat = self._embedding_to_features(x)
+
+        return pitch_hat, velocity_hat, dstart_hat, duration_hat
+
+
+# if __name__ == "__main__":
+#     p = torch.randint(0, 88, (1, 128)).to("cuda")
+#     v = torch.randint(0, 128, (1, 128)).to("cuda")
+#     s = torch.rand((1, 128)).to("cuda")
+#     e = torch.rand((1, 128)).to("cuda")
+
+#     m = MidiVQVAETransformer().to("cuda")
+
+#     out = m(p, v, s, e)
+
+#     print(out[0].shape)

--- a/train_vqvae_transformer.py
+++ b/train_vqvae_transformer.py
@@ -237,6 +237,7 @@ def train(cfg: OmegaConf):
         num_heads=cfg.model.num_heads,
         fsq_levels=cfg.model.fsq_levels,
         mlp_ratio=cfg.model.mlp_ratio,
+        change_resolution_at_depth=cfg.model.change_resolution_at_depth,
     ).to(device)
 
     # checkpoint save path

--- a/train_vqvae_transformer.py
+++ b/train_vqvae_transformer.py
@@ -1,0 +1,371 @@
+import os
+from collections import Counter
+
+import hydra
+import torch
+import torch.optim as optim
+import torch.nn.functional as F
+from omegaconf import OmegaConf
+import torchmetrics.functional as M
+from huggingface_hub import upload_file
+from torch.utils.data import Subset, DataLoader
+from datasets import load_dataset, concatenate_datasets
+
+import wandb
+from utils import MidiFeaturesWithStartEnd
+from models.vqvae_transformer import MidiVQVAETransformer
+from data.dataset import MidiDatasetWithStartEnd
+
+
+def print_metrics(metrics: dict):
+    text = "|".join([f"{k}: {v:.2f}" for k, v in metrics.items()])
+
+    print(text)
+
+
+def makedir_if_not_exists(dir: str):
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+
+
+def preprocess_dataset(
+    dataset_names: list[str],
+    batch_size: int,
+    num_workers: int,
+    pitch_shift_probability: float,
+    time_stretch_probability: float,
+    *,
+    overfit_single_batch: bool = False,
+):
+    hf_token = os.environ["HUGGINGFACE_TOKEN"]
+
+    train_ds = []
+    val_ds = []
+    test_ds = []
+
+    for dataset_name in dataset_names:
+        tr_ds = load_dataset(dataset_name, split="train", use_auth_token=hf_token)
+        v_ds = load_dataset(dataset_name, split="validation", use_auth_token=hf_token)
+        t_ds = load_dataset(dataset_name, split="test", use_auth_token=hf_token)
+
+        train_ds.append(tr_ds)
+        val_ds.append(v_ds)
+        test_ds.append(t_ds)
+
+    train_ds = concatenate_datasets(train_ds)
+    val_ds = concatenate_datasets(val_ds)
+    test_ds = concatenate_datasets(test_ds)
+
+    train_ds = MidiDatasetWithStartEnd(
+        train_ds,
+        pitch_shift_probability=pitch_shift_probability,
+        time_stretch_probability=time_stretch_probability,
+    )
+    val_ds = MidiDatasetWithStartEnd(
+        val_ds,
+        pitch_shift_probability=0.0,
+        time_stretch_probability=0.0,
+    )
+    test_ds = MidiDatasetWithStartEnd(
+        test_ds,
+        pitch_shift_probability=0.0,
+        time_stretch_probability=0.0,
+    )
+
+    if overfit_single_batch:
+        train_ds = Subset(train_ds, indices=range(batch_size))
+        val_ds = Subset(val_ds, indices=range(batch_size))
+        test_ds = Subset(test_ds, indices=range(batch_size))
+
+    # dataloaders
+    train_dataloader = DataLoader(train_ds, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+    val_dataloader = DataLoader(val_ds, batch_size=batch_size, num_workers=num_workers)
+    test_dataloader = DataLoader(test_ds, batch_size=batch_size, num_workers=num_workers)
+
+    return train_dataloader, val_dataloader, test_dataloader
+
+
+def forward_step(
+    model: MidiVQVAETransformer,
+    batch: MidiFeaturesWithStartEnd,
+    loss_lambdas: list,
+):
+    pred_pitch, pred_velocity, pred_dstart, pred_duration = model(
+        pitch=batch.pitch,
+        velocity=batch.velocity,
+        start=batch.start,
+        end=batch.end,
+    )
+
+    pred_pitch = pred_pitch.permute(0, 2, 1)
+    pred_velocity = pred_velocity.permute(0, 2, 1)
+
+    # calculate losses
+    pitch_loss = F.cross_entropy(pred_pitch, batch.pitch)
+    velocity_loss = F.cross_entropy(pred_velocity, batch.velocity)
+    dstart_loss = F.mse_loss(pred_dstart, batch.dstart)
+    duration_loss = F.mse_loss(pred_duration, batch.duration)
+
+    # shape: [num_losses, ]
+    losses = torch.stack([pitch_loss, velocity_loss, dstart_loss, duration_loss])
+
+    loss = loss_lambdas @ losses
+
+    pitch_acc = (torch.argmax(pred_pitch, dim=1) == batch.pitch).float().mean()
+    velocity_acc = (torch.argmax(pred_velocity, dim=1) == batch.velocity).float().mean()
+    dstart_r2 = M.r2_score(pred_dstart, batch.dstart)
+    duration_r2 = M.r2_score(pred_duration, batch.duration)
+
+    metrics = {
+        "loss": loss.item(),
+        "pitch_loss": pitch_loss.item(),
+        "velocity_loss": velocity_loss.item(),
+        "dstart_loss": dstart_loss.item(),
+        "duration_loss": duration_loss.item(),
+        "pitch_acc": pitch_acc.item(),
+        "velocity_acc": velocity_acc.item(),
+        "dstart_r2": dstart_r2.item(),
+        "duration_r2": duration_r2.item(),
+        "goal_weighted_sum": ((pitch_acc + velocity_acc + dstart_r2 + duration_r2) / 4).item(),
+    }
+
+    return loss, metrics
+
+
+@torch.no_grad()
+def validation_epoch(
+    model: MidiVQVAETransformer,
+    dataloader: DataLoader,
+    loss_lambdas: torch.Tensor,
+    device: torch.device,
+    cfg: OmegaConf,
+) -> dict:
+    # val epoch
+    metrics_epoch = Counter(
+        {
+            "loss": 0.0,
+            "pitch_loss": 0.0,
+            "velocity_loss": 0.0,
+            "dstart_loss": 0.0,
+            "duration_loss": 0.0,
+            "pitch_acc": 0.0,
+            "velocity_acc": 0.0,
+            "dstart_r2": 0.0,
+            "duration_r2": 0.0,
+            "goal_weighted_sum": 0.0,
+        }
+    )
+
+    for batch_idx, batch in enumerate(dataloader):
+        batch = MidiFeaturesWithStartEnd(
+            filename=batch["filename"],
+            source=batch["source"],
+            pitch=batch["pitch"],
+            velocity=batch["velocity"],
+            dstart=batch["dstart"],
+            duration=batch["duration"],
+            start=batch["start"],
+            end=batch["end"],
+        )
+
+        batch.to_(device)
+        # metrics returns loss and additional metrics if specified in step function
+        _, metrics = forward_step(model, batch, loss_lambdas)
+
+        if (batch_idx + 1) % cfg.logger.log_every_n_steps == 0:
+            print_metrics(metrics)
+        metrics_epoch += Counter(metrics)
+
+    return metrics_epoch
+
+
+def save_checkpoint(model: MidiVQVAETransformer, optimizer: optim.Optimizer, cfg: OmegaConf, save_path: str):
+    # saving models
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "config": cfg,
+        },
+        f=save_path,
+    )
+
+
+def upload_to_huggingface(ckpt_save_path: str, cfg: OmegaConf):
+    # get huggingface token from environment variables
+    token = os.environ["HUGGINGFACE_TOKEN"]
+
+    # upload model to hugging face
+    upload_file(ckpt_save_path, path_in_repo=f"{cfg.logger.run_name}.ckpt", repo_id=cfg.paths.hf_repo_id, token=token)
+
+
+@hydra.main(config_path="configs", config_name="config-transformer", version_base="1.3.2")
+def train(cfg: OmegaConf):
+    wandb.login()
+
+    # create dir if they don't exist
+    makedir_if_not_exists(cfg.paths.log_dir)
+    makedir_if_not_exists(cfg.paths.save_ckpt_dir)
+
+    # dataset
+    train_dataloader, val_dataloader, _ = preprocess_dataset(
+        dataset_names=cfg.train.dataset_names,
+        batch_size=cfg.train.batch_size,
+        num_workers=cfg.train.num_workers,
+        pitch_shift_probability=cfg.train.pitch_shift_probability,
+        time_stretch_probability=cfg.train.time_stretch_probability,
+        overfit_single_batch=cfg.train.overfit_single_batch,
+    )
+
+    # validate on quantized maestro
+    # This dataset is already in cfg.train.dataset_names - is this unneccessary duplication?
+    _, maestro_test, _ = preprocess_dataset(
+        dataset_names=["JasiekKaczmarczyk/maestro-v1-sustain-masked"],
+        batch_size=cfg.train.batch_size,
+        num_workers=cfg.train.num_workers,
+        pitch_shift_probability=cfg.train.pitch_shift_probability,
+        time_stretch_probability=cfg.train.time_stretch_probability,
+        overfit_single_batch=cfg.train.overfit_single_batch,
+    )
+
+    device = torch.device(cfg.train.device)
+
+    # model
+    model = MidiVQVAETransformer(
+        dim=cfg.model.dim,
+        depth=cfg.model.depth,
+        num_heads=cfg.model.num_heads,
+        fsq_levels=cfg.model.fsq_levels,
+        mlp_ratio=cfg.model.mlp_ratio,
+    ).to(device)
+
+    # checkpoint save path
+    num_params_millions = sum([p.numel() for p in model.parameters()]) / 1_000_000
+    run_name = f"{cfg.logger.run_name}-{num_params_millions:.2f}M.ckpt"
+    save_path = f"{cfg.paths.save_ckpt_dir}/{run_name}"
+
+    # logger
+    wandb.init(
+        project="midi-vqvae-transformer",
+        name=run_name,
+        dir=cfg.paths.log_dir,
+        config=OmegaConf.to_container(cfg, resolve=True),
+    )
+
+    # setting up optimizer
+    optimizer = optim.AdamW(model.parameters(), lr=cfg.train.lr, weight_decay=cfg.train.weight_decay)
+
+    # get loss lambdas as tensor
+    loss_lambdas = torch.tensor(list(cfg.train.loss_lambdas.values()), dtype=torch.float, device=device)
+
+    # load checkpoint if specified in cfg
+    if cfg.paths.load_ckpt_path is not None:
+        checkpoint = torch.load(cfg.paths.load_ckpt_path)
+
+        model.load_state_dict(checkpoint["model"])
+        optimizer.load_state_dict(checkpoint["optimizer"])
+
+    # step counts for logging to wandb
+    step_count = 0
+    notes_processed = 0
+
+    for epoch in range(cfg.train.num_epochs):
+        # train epoch
+        model.train()
+        training_metrics_epoch = Counter(
+            {
+                "loss": 0.0,
+                "pitch_loss": 0.0,
+                "velocity_loss": 0.0,
+                "dstart_loss": 0.0,
+                "duration_loss": 0.0,
+                "pitch_acc": 0.0,
+                "velocity_acc": 0.0,
+                "dstart_r2": 0.0,
+                "duration_r2": 0.0,
+                "goal_weighted_sum": 0.0,
+            }
+        )
+
+        for batch_idx, batch in enumerate(train_dataloader):
+            batch = MidiFeaturesWithStartEnd(
+            filename=batch["filename"],
+            source=batch["source"],
+            pitch=batch["pitch"],
+            velocity=batch["velocity"],
+            dstart=batch["dstart"],
+            duration=batch["duration"],
+            start=batch["start"],
+            end=batch["end"],
+        )
+
+            batch.to_(device)
+
+            # metrics returns loss and additional metrics if specified in step function
+            loss, metrics = forward_step(model, batch, loss_lambdas)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            step_count += 1
+            notes_processed += torch.numel(batch.pitch)
+
+            training_metrics_epoch += Counter(metrics)
+
+            if (step_count + 1) % cfg.logger.log_every_n_steps == 0:
+                metrics = {"epoch": epoch, "step": step_count, "notes_processed": notes_processed} | metrics
+                print_metrics(metrics)
+
+                metrics |= {"learning_rate": cfg.train.lr}
+                metrics = {"train/" + key: value for key, value in metrics.items()}
+
+                # log metrics
+                wandb.log(metrics, step=step_count)
+
+                # save model and optimizer states
+                save_checkpoint(model, optimizer, cfg, save_path=save_path)
+
+        training_metrics_epoch = {
+            "train_epoch/" + key: value / len(train_dataloader) for key, value in training_metrics_epoch.items()
+        }
+
+        model.eval()
+
+        # val epoch
+        print("Validation")
+        val_metrics_epoch = validation_epoch(
+            model=model,
+            dataloader=val_dataloader,
+            loss_lambdas=loss_lambdas,
+            device=device,
+            cfg=cfg,
+        )
+        val_metrics_epoch = {"val_epoch/" + key: value / len(val_dataloader) for key, value in val_metrics_epoch.items()}
+
+        # maestro test epoch
+        print("Test (maestro)")
+        test_metrics_epoch = validation_epoch(
+            model=model,
+            dataloader=maestro_test,
+            loss_lambdas=loss_lambdas,
+            device=device,
+            cfg=cfg,
+        )
+        test_metrics_epoch = {"maestro_epoch/" + key: value / len(maestro_test) for key, value in test_metrics_epoch.items()}
+
+        metrics_epoch = training_metrics_epoch | val_metrics_epoch | test_metrics_epoch
+        wandb.log(metrics_epoch, step=step_count)
+
+    # save model at the end of training
+    save_checkpoint(model, optimizer, cfg, save_path=save_path)
+
+    wandb.finish()
+
+    # upload model to huggingface if specified in cfg
+    if cfg.paths.hf_repo_id is not None:
+        upload_to_huggingface(save_path, cfg)
+
+
+if __name__ == "__main__":
+    train()

--- a/utils.py
+++ b/utils.py
@@ -15,3 +15,22 @@ class MidiFeatures:
         self.velocity = self.velocity.to(device)
         self.dstart = self.dstart.to(device)
         self.duration = self.duration.to(device)
+
+@dataclass
+class MidiFeaturesWithStartEnd:
+    filename: str
+    source: str
+    pitch: torch.Tensor
+    velocity: torch.Tensor
+    dstart: torch.Tensor
+    duration: torch.Tensor
+    start: torch.Tensor
+    end: torch.Tensor
+
+    def to_(self, device: torch.device):
+        self.pitch = self.pitch.to(device)
+        self.velocity = self.velocity.to(device)
+        self.dstart = self.dstart.to(device)
+        self.duration = self.duration.to(device)
+        self.start = self.start.to(device)
+        self.end = self.end.to(device)


### PR DESCRIPTION
to run training:
```python
python train_vqvae_transformer.py --config-name config-transformer
```

I ran a few test runs and I found that downsampling is the bottleneck, so I tried using this model without it, so it only encodes the data without compressing it. It learned pitch and velocity almost perfectly and duration pretty good but there is still problem with dstart.
https://wandb.ai/jasiekkaczmarczyk/midi-vqvae-transformer/runs/b2pwwifx

I also tried predicting start and end instead of dstart and duration but the network couldn't learn anything. There is a possibility that normalizing those values could help, but I have also another idea in which heads will predict sinusoidal embeddings instead of single value for start/end (I think transformation from positions to sinusoidal embeddings is invertible) and from those predicted embeddings we can obtain start/end.